### PR TITLE
1 feature request optional role ping on alt match with cheating ban

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The AltChecker plugin, originally developed by JetDave, has been revamped into a
     "showCBLInfo": true,
     "showCheaterBans": true,
     "enableCheaterAltKicks": true,
+    "roleID": "",
+    "rolePingForCheaterAlt": true,
     "adminChatChannelID": "your_admin_chat_channel_id"
 }
 ```


### PR DESCRIPTION
### Changelog Summary

**Version: 1.1.0 (Beta)**

#### New Features:
1. **Language-Based Cheating Ban Detection**:
   - Added support to detect cheating bans in multiple languages (French, Spanish, Italian, etc.).

2. **Role Ping for Cheater Alt Detection**:
   - Added a new configuration option `rolePingForCheaterAlt`.
   - If enabled and a `roleID` is defined, the specified role will be pinged in the admin chat when a cheater alt is detected.

3. **Configuration Options for Embeds**:
   - Introduced `enableBMBans` config option to enable or disable fetching and displaying BattleMetrics ban information.
   - Enhanced the logic to conditionally include Community Ban List (CBL) and cheater ban information based on config options.

#### Improvements:
1. **Connection Delay for Kicking Players**:
   - Implemented a delay before kicking players to ensure they are fully connected.

2. **Handling Embed Character Limits**:
   - Added logic to split long embeds into multiple parts if they exceed Discord’s 6,000 character limit.

#### Bug Fixes:
1. **EOS ID Handling**:
   - Fixed an issue where missing EOS IDs caused incorrect cheater ban detections.

2. **Proper Formatting in Embeds**:
   - Ensured proper spacing and formatting in embeds even when certain information is disabled.

3. **False Cheater Ban Triggers**:
   - Addressed issues causing false cheater ban triggers due to missing or incorrectly parsed EOS IDs.

#### Configuration Changes:
- **New Config Options**:
  - `enableBMBans`: Enable or disable fetching and displaying BattleMetrics ban information.
  - `rolePingForCheaterAlt`: Enable or disable role pinging in the admin chat when a cheater alt is detected.
  - `roleID`: Define the role ID to be pinged when `rolePingForCheaterAlt` is enabled.

**Note**: This release is a beta version intended for testing the new features and improvements. It is not recommended for public use at this stage.